### PR TITLE
Fixed bug where writing next to a mention would cause it to dissapear

### DIFF
--- a/src/Editor/index.js
+++ b/src/Editor/index.js
@@ -493,17 +493,6 @@ export class Editor extends React.Component {
                 start: selection.end,
                 end: text.length
             }, charAdded, true);
-            /**
-             * if user type anything on the mention
-             * remove the mention from the mentions array
-             * */
-            if (selection.start === selection.end) {
-                const key = EU.findMentionKeyInMap(this.mentionsMap, (selection.start - 1));
-                if (key && key.length) {
-                    this.mentionsMap.delete(key);
-                }
-            }
-
         }
 
         this.setState({


### PR DESCRIPTION
Now mentions are only deleted when pressing backspace. This fixes the bug in Android where opening a note which ended in a mention and writing anything would cause to delete the mention.